### PR TITLE
Fixed errors, interactive works now.

### DIFF
--- a/cli_passthrough/_passthrough.py
+++ b/cli_passthrough/_passthrough.py
@@ -15,14 +15,13 @@ def cli_passthrough(cmd=None, interactive=False):
         cmd = ["/bin/bash", "-i", "-c"] + cmd.split()
     else:
         cmd = cmd.split()
-
-    with Popen(cmd, stdin=slaves[0], stdout=slaves[0], stderr=slaves[1]) as p:
+    with Popen(cmd, stdin=sys.stdin, stdout=slaves[0], stderr=slaves[1]) as p:
         for fd in slaves:
             os.close(fd)  # no input
-            readable = {
-                masters[0]: sys.stdout.buffer,  # store buffers seperately
-                masters[1]: sys.stderr.buffer,
-            }
+        readable = {
+            masters[0]: sys.stdout.buffer,  # store buffers seperately
+            masters[1]: sys.stderr.buffer,
+        }
         while readable:
             for fd in select(readable, [], [])[0]:
                 try:
@@ -36,9 +35,9 @@ def cli_passthrough(cmd=None, interactive=False):
                         del readable[fd]
                     else:
                         if fd == masters[0]:  # We caught stdout
-                            echo(data.rstrip())
+                            echo(data)
                         else:  # We caught stderr
-                            echo(data.rstrip(), err=True)
+                            echo(data, err=True)
                         readable[fd].flush()
     for fd in masters:
         os.close(fd)

--- a/cli_passthrough/utils.py
+++ b/cli_passthrough/utils.py
@@ -6,10 +6,10 @@ import click
 def echo(msg, err=None):
     if err:
         write_to_log(msg, "stderr")
-        click.echo(msg, err=err)
+        click.echo(msg, nl=False, err=err)
     else:
         write_to_log(msg)
-        click.echo(msg)
+        click.echo(msg, nl=False)
 
 
 def write_to_log(data=None, file_name=None):


### PR DESCRIPTION
Fixed some errors.

Redirecting sys.stdin to process now, so interactive processes work. Usually the stdin is echoed back, so everything should be logged anyway.

As example: 
  * use passwd with stdin not being echoed back, 
  * and ftp where stdin is echoed back.