### PR TITLE
[silent-commands] silent-commands

### DIFF
--- a/cli_passthrough/__init__.py
+++ b/cli_passthrough/__init__.py
@@ -1,3 +1,3 @@
-from ._passthrough import cli_passthrough
+from cli_passthrough._passthrough import cli_passthrough
 
 __all__ = [cli_passthrough]

--- a/cli_passthrough/cli.py
+++ b/cli_passthrough/cli.py
@@ -4,7 +4,6 @@ import click
 import pkg_resources
 
 from . import cli_passthrough
-from .utils import write_to_log
 
 version = pkg_resources.get_distribution("cli-passthrough").version
 CONTEXT_SETTINGS = {"ignore_unknown_options": True, "allow_extra_args": True}
@@ -20,15 +19,19 @@ CONTEXT_SETTINGS = {"ignore_unknown_options": True, "allow_extra_args": True}
     "effectively sourcing the .bashrc file. "
     "This may use any aliases set in your current env.",
 )
+@click.option(
+    "-s",
+    "--silent",
+    is_flag=True,
+    help="Supress stdout and stderr. This will only remove display coming from stdout. "
+    "Some commands may still alter the display.",
+)
 @click.version_option(prog_name="cli-passthrough", version=version)
 @click.pass_context
-def cli(ctx, interactive):
+def cli(ctx, interactive, silent):
     """Entry point
     """
-    write_to_log("\nNEW CMD = {}".format(" ".join(sys.argv)))
-    write_to_log("\nNEW CMD = {}".format(" ".join(sys.argv)), "stderr")
-
-    exit_status = cli_passthrough(" ".join(ctx.args), interactive)
+    exit_status = cli_passthrough(" ".join(ctx.args), interactive, silent)
     sys.exit(exit_status)
 
 

--- a/cli_passthrough/utils.py
+++ b/cli_passthrough/utils.py
@@ -1,27 +1,29 @@
 import os
+from pathlib import Path
 
 import click
 
 
-def echo(msg, err=None):
+def echo(msg, err=False, silent=False):
     if err:
-        write_to_log(msg, "stderr")
-        click.echo(msg, nl=False, err=err)
+        write_to_log(msg, "stderr.log")
+        if not silent:
+            click.echo(msg, nl=False, err=err)
     else:
         write_to_log(msg)
-        click.echo(msg, nl=False)
+        if not silent:
+            click.echo(msg, nl=False)
 
 
-def write_to_log(data=None, file_name=None):
-    """Write data to log files. Will append data to a single combined log.
+def write_to_log(data, additional_log=None):
+    """Write data to log files. Will append data to a single combined log called history.log.
     Additionally write data to a log with a custom name (such as stderr)
     for any custom logs.
 
     Args:
         data (str or bytes): Data to write to log file.
-        file_name (str): Used to create (or append to) an additional
-                         log file with a custom name. Custom name always gets
-                         `.log` added to the end.
+        additional_log (str): Used to create (or append to) an additional
+                         log file with a custom name.
     """
     try:
         data = data.decode("utf-8")
@@ -30,16 +32,14 @@ def write_to_log(data=None, file_name=None):
 
     # strip possible eol chars and add back exactly one
     data = "".join([data.rstrip(), "\n"])
-    logpath = "logs"
+
+    logpath = Path("logs")
     if not os.path.exists(logpath):
         os.makedirs(logpath)
 
-    fd_path = os.path.join(logpath, "history.log")
-    fd = open(fd_path, "a+")
-    fd.write(data)
-    fd.close()
-    if file_name:
-        fd_custom_path = os.path.join(logpath, "".join([file_name, ".log"]))
-        fd_custom = open(fd_custom_path, "a+")
-        fd_custom.write(data)
-        fd_custom.close()
+    with open(logpath / "history.log", "a+") as fp:
+        fp.write(data)
+
+    if additional_log:
+        with open(logpath / additional_log, "a+") as fp:
+            fp.write(data)


### PR DESCRIPTION
Resolves #2 

With this you can pass an option to not echo stdout and stderr.

This also cleans up the logging a bit.